### PR TITLE
revert workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,47 +1,51 @@
 name: Deploy Project to App Engine
+
 on:
   push:
     branches:
       - main
       - dev-to-gcloud
+
   # run the workflow manually from the Actions tab
   workflow_dispatch:
+
 jobs:
-  deploy:
-    name: Deploying to Google Cloud
-    runs-on: ubuntu-latest
-    #needs: test  # Uncomment this if you want the deploy job to wait for the test job to complete successfully
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0.3.0
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SERVICE_CREDENTIALS }}
-          export_default_credentials: true
-
-      - name: Deploy to App Engine with verbosity debug
-        run: |
-          gcloud app deploy app.yaml --version=v5 --verbosity=debug --project=sopra-fs24-group-38-server
-        env:
-          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-
-      - name: Check deployment
-        run: curl "${{ steps.deploy.outputs.url }}"
   test:
     name: Test and Sonarqube
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v4
+
       - name: Install Java 17
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: "17"
+
       - name: Test and analyze
         run: ./gradlew test jacocoTestReport sonar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  deploy:
+    name: Deploying to Google Cloud
+    runs-on: ubuntu-latest
+    # needs: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Deploy to App Engine
+        id: deploy
+        uses: google-github-actions/deploy-appengine@v0.2.0
+        with:
+          deliverables: app.yaml
+          version: v1
+          credentials: ${{ secrets.GCP_SERVICE_CREDENTIALS }}
+
+      - name: Test
+        run: curl "${{ steps.deploy.outputs.url }}"


### PR DESCRIPTION
Back to the old deploy workflow but still include the dev-to-gcloud branch setting for deployment tests. 